### PR TITLE
Implement colors in windows terminal

### DIFF
--- a/src/pocketmine/utils/Terminal.php
+++ b/src/pocketmine/utils/Terminal.php
@@ -46,7 +46,10 @@ abstract class Terminal{
 			if(isset($opts["disable-ansi"])){
 				Terminal::$formattingCodes = false;
 			}else{
-				Terminal::$formattingCodes = ((Utils::getOS() !== "win" and getenv("TERM") != "" and (!function_exists("posix_ttyname") or !defined("STDOUT") or posix_ttyname(STDOUT) !== false)) or isset($opts["enable-ansi"]));
+				Terminal::$formattingCodes = (isset($opts["enable-ansi"]) or (stream_isatty(STDOUT) and (
+						getenv('TERM') !== false or (function_exists('sapi_windows_vt100_support') and sapi_windows_vt100_support(STDOUT))
+					)
+				));
 			}
 		}
 


### PR DESCRIPTION
Now you can see the colors while launching DS on Windows.
Before:
![image](https://user-images.githubusercontent.com/32373441/33526759-c3806782-d856-11e7-9df8-e3b2e5e70456.png)
After:
![image](https://user-images.githubusercontent.com/32373441/33526765-da38e6ca-d856-11e7-9ecd-6b5b007cfe72.png)
UPD: I can dev something in DS. Also I can implement russian translations since Im from Russia. Just for note to @DarkYusuf13